### PR TITLE
[feature/12] Updated branch naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,23 +101,23 @@ On `issues.opened`:
 On `issues.assigned`:
 - Ensures issue has Type (`bug|feature|task`).
 - Creates a linked branch from `dev`, else `main`, else `master`.
-- Branch format: `type/issue_number` (example: `bug/12`).
+- Branch format: `type/#issue_number` (example: `bug/#12`). Legacy format `type/issue_number` is also supported for backwards compatibility.
 - Linked branch appears under the issue Development section (same behavior as GitHub UI "Create branch").
 
 On `create` (branch created):
-- If branch matches `type/issue_number` and the referenced issue is open, bot attempts to attach it to that issue’s Development section.
+- If branch matches `type/#issue_number` (or legacy `type/issue_number`) and the referenced issue is open, bot attempts to attach it to that issue's Development section.
 
 ### Pull requests
 
 For PRs targeting `dev`, `main`, or `master`:
-- Source branch must be `type/issue_number`.
+- Source branch must be `type/#issue_number` (example: `bug/#12`). Legacy format `type/issue_number` is also accepted.
 - Allowed type values: `bug`, `feature`, `task`.
 - Exception: PRs into `main/master` may come from `dev`.
 - Referenced issue must exist and be open.
 - Branch type must match referenced issue Type.
 - Branch must be rebased on target base branch.
 - PR must contain exactly one commit (squashed).
-- Commit message(s) must start with `[branch_name] ` (example: `[bug/12] Fix null guard`).
+- Commit message(s) must start with `[branch_name]<space>` (example: `[bug/#12] Fix null guard`). The `#` in the commit prefix creates a clickable issue link in GitHub.
 - Bot ensures PR body includes an issue-closing link (for example `Closes #123`) so merge auto-closes linked issue.
 
 Security gates:

--- a/src/index.js
+++ b/src/index.js
@@ -287,7 +287,7 @@ module.exports = (app) => {
     }
 
     const baseBranch = await findBaseBranch(context, owner, repo, repository.default_branch);
-    const branchName = `${slugify(issueType)}/${issue.number}`;
+    const branchName = `${slugify(issueType)}/#${issue.number}`;
 
     const branchExists = await doesBranchExist(context, owner, repo, branchName);
 
@@ -549,7 +549,7 @@ async function evaluatePullRequestComplianceCore(context, repository, pullReques
   const branchFormatPassed = !policy.pullRequest.requireBranchNaming || Boolean(parsedBranch || isDevPromotion);
   if (!branchFormatPassed) {
     failures.push(
-      `Source branch must follow \`type/issue_number\` (example: \`bug/12\`). For PRs into \`main\` or \`master\`, \`dev\` is also allowed.`
+      `Source branch must follow \`type/#issue_number\` (example: \`bug/#12\`). For PRs into \`main\` or \`master\`, \`dev\` is also allowed. Legacy format \`type/issue_number\` is also accepted.`
     );
   }
   checks.push({
@@ -559,7 +559,7 @@ async function evaluatePullRequestComplianceCore(context, repository, pullReques
       ? "Disabled by repository override."
       : branchFormatPassed
       ? `Using source branch \`${headBranch}\`.`
-      : "Expected `type/issue_number` or `dev` when targeting main/master.",
+      : "Expected `type/#issue_number` (or legacy `type/issue_number`) or `dev` when targeting main/master.",
   });
 
   if (parsedBranch) {
@@ -631,11 +631,11 @@ async function evaluatePullRequestComplianceCore(context, repository, pullReques
       detail: "Not required for `dev` promotion into `main/master`.",
     });
   } else if (policy.pullRequest.requireIssueReference || policy.pullRequest.requireIssueOpen || policy.pullRequest.requireIssueTypeMatch) {
-    failures.push("Branch does not map to `type/issue_number`, so issue requirements cannot be validated.");
+    failures.push("Branch does not map to `type/#issue_number` (or legacy `type/issue_number`), so issue requirements cannot be validated.");
     checks.push({
       name: "Referenced issue validity",
       passed: false,
-      detail: "Expected `type/issue_number` branch to validate issue requirements.",
+      detail: "Expected `type/#issue_number` (or legacy `type/issue_number`) branch to validate issue requirements.",
     });
   } else {
     checks.push({
@@ -1034,7 +1034,8 @@ function parseRecheckCommand(body) {
 }
 
 function parseTypeIssueBranch(branchName) {
-  const match = String(branchName || "").match(/^([a-z][a-z0-9-]*)\/(\d+)$/i);
+  // Support both type/#issue (new format) and type/issue (legacy format)
+  const match = String(branchName || "").match(/^([a-z][a-z0-9-]*)\/[#]?(\d+)$/i);
   if (!match) {
     return null;
   }
@@ -1275,7 +1276,7 @@ async function ensureIssueAutocloseReference(context, owner, repo, pullRequest, 
   if (!parsedBranch) {
     return {
       passed: false,
-      detail: "Cannot add issue auto-close link because branch does not map to `type/issue_number`.",
+      detail: "Cannot add issue auto-close link because branch does not map to `type/#issue_number` (or legacy `type/issue_number`).",
       failures: ["Unable to add issue auto-close link because issue number is not derivable from branch name."],
     };
   }


### PR DESCRIPTION
## Summary by Sourcery

Update the branch naming convention to support a new `type/#issue_number` format while maintaining backward compatibility with the legacy `type/issue_number` format.

New Features:
- Adopt `type/#issue_number` as the default branch naming scheme for issue-linked branches and commit prefixes.

Enhancements:
- Extend branch parsing logic and compliance messaging to accept both the new `type/#issue_number` and legacy `type/issue_number` formats.
- Clarify README documentation around branch naming, commit message prefixes, and the behavior of clickable issue links in GitHub.

<!-- kumpeapps-issue-autoclose -->
Closes #12